### PR TITLE
Hotfix: Ensure Playground tables have primary indexes

### DIFF
--- a/database/migrations/2024_04_19_111613_create_playground_tables.php
+++ b/database/migrations/2024_04_19_111613_create_playground_tables.php
@@ -10,13 +10,13 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('playground_sessions', function (Blueprint $table) {
-            $table->uuid('id');
+            $table->uuid('id')->primary();
             $table->ipAddress()->nullable();
             $table->timestamps();
         });
 
         Schema::create('playground_notams', function (Blueprint $table) {
-            $table->uuid('id');
+            $table->uuid('id')->primary();
             $table->foreignIdFor(PlaygroundSession::class, 'session_id');
             $table->text('text');
             $table->string('tag', 2)->nullable();


### PR DESCRIPTION
#1 introduces an issue where the created tables do not have primary indexes. This PR fixes this.

Given the app remains in alpha, I opted not to create a separate migration. Deployment will therefore require manually rolling back the previous migration and remigrating:
1. `php artisan migrate:rollback`
2. `php artisan migrate`