### PR TITLE
Fix bug where cursor would jump to the end of playground input

### DIFF
--- a/resources/views/components/playground/input-group.blade.php
+++ b/resources/views/components/playground/input-group.blade.php
@@ -10,7 +10,7 @@
             wire:loading.attr="readonly"
             class="block w-full resize-none border-0 bg-transparent py-2 text-gray-900 placeholder:text-gray-400 focus:ring-0"
             placeholder="Paste in a NOTAM to play with…"
-            oninput="this.value = this.value.toUpperCase()"
+            oninput="let p = this.selectionStart; this.value = this.value.toUpperCase(); this.setSelectionRange(p, p);"
             x-ref="input"
             @error('form.notam')
             aria-invalid="true" aria-describedby="notam-error"


### PR DESCRIPTION
In the current implementation of the Playground, in order to facilitate inputing NOTAMs, the input automatically capitalizes all inputted text.

This is accomplished with the following attribute on the `<textarea>` element:
```
oninput="this.value = this.value.toUpperCase()"
```

This introduced a bug where the cursor jumps to the end of the input string when the input string is changed elsewhere than at its end.

This PR fixes this annoyance by capturing the cursor position prior to capitalization and restoring it afterwards:
```
oninput="let p = this.selectionStart; this.value = this.value.toUpperCase(); this.setSelectionRange(p, p);"
```